### PR TITLE
chore: remove outbound servers for dfsps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,9 +129,9 @@ jobs:
             sleep 10
             docker-compose up -d central-settlement
             sleep 10
-            docker-compose up -d dfspa-sdk-scheme-adapter dfspa-thirdparty-sdk-inbound dfspa-thirdparty-sdk-outbound
+            docker-compose up -d dfspa-sdk-scheme-adapter dfspa-thirdparty-sdk-inbound
             sleep 10
-            docker-compose up -d dfspb-sdk-scheme-adapter dfspb-thirdparty-sdk-inbound dfspb-thirdparty-sdk-outbound
+            docker-compose up -d dfspb-sdk-scheme-adapter dfspb-thirdparty-sdk-inbound
             sleep 10
             docker-compose up -d login-flow-simulator-ui login-flow-simulator
             sleep 10

--- a/docker-live/charts-participant/templates/mojaloop-simulator.yaml
+++ b/docker-live/charts-participant/templates/mojaloop-simulator.yaml
@@ -42,8 +42,6 @@ spec:
               value: {{ $participantId }}
             - name: OUTBOUND_ENDPOINT
               value: http://{{ $participantId }}-sdk-scheme-adapter:4001
-            - name: THIRDPARTY_OUTBOUND_ENDPOINT
-              value: http://{{ $participantId }}-thirdparty-sdk:4005
             - name: HTTPS_ENABLED
               value: 'false'
             - name: MUTUAL_TLS_ENABLED

--- a/docker-local/README.md
+++ b/docker-local/README.md
@@ -69,8 +69,8 @@ npm install
 - A hosts file with the following entries:
 ```
 127.0.0.1       central-ledger.local central-settlement.local ml-api-adapter.local account-lookup-service.local account-lookup-service-admin.local quoting-service.local moja-simulator.local central-ledger central-settlement ml-api-adapter account-lookup-service account-lookup-service-admin quoting-service simulator host.docker.internal transaction-request-service
-127.0.0.1 dfspa-backend dfspa-thirdparty-sdk-inbound dfspa-thirdparty-sdk-outbound dfspa-sdk-scheme-adapter
-127.0.0.1 dfspb-backend dfspb-thirdparty-sdk-inbound dfspb-thirdparty-sdk-outbound dfspb-sdk-scheme-adapter
+127.0.0.1 dfspa-backend dfspa-thirdparty-sdk-inbound dfspa-sdk-scheme-adapter
+127.0.0.1 dfspb-backend dfspb-thirdparty-sdk-inbound dfspb-sdk-scheme-adapter
 127.0.0.1 pisp-backend pisp-thirdparty-sdk-inbound pisp-thirdparty-sdk-outbound pisp-sdk-scheme-adapter
 127.0.0.1 als-consent-oracle
 127.0.0.1 auth-service
@@ -99,8 +99,8 @@ docker-compose logs -f quoting-service
 docker-compose logs -f ml-api-adapter
 docker-compose logs -f central-settlement
 docker-compose logs -f account-lookup-service
-docker-compose logs -f dfspa-sdk-scheme-adapter dfspa-backend dfspa-thirdparty-sdk-inbound dfspa-thirdparty-sdk-outbound
-docker-compose logs -f dfspb-sdk-scheme-adapter dfspb-backend dfspb-thirdparty-sdk-inbound dfspb-thirdparty-sdk-outbound
+docker-compose logs -f dfspa-sdk-scheme-adapter dfspa-backend dfspa-thirdparty-sdk-inbound
+docker-compose logs -f dfspb-sdk-scheme-adapter dfspb-backend dfspb-thirdparty-sdk-inbound
 docker-compose logs -f transaction-requests-service
 docker-compose logs -f pisp-backend  pisp-sdk-scheme-adapter pisp-redis pisp-thirdparty-sdk-inbound pisp-thirdparty-sdk-outbound
 ```

--- a/docker-local/dfsp_a/dfsp_a_backend.env
+++ b/docker-local/dfsp_a/dfsp_a_backend.env
@@ -31,7 +31,6 @@ MODEL_DATABASE=./model.sqlite
 
 # Outbound API endpoint (It might be a container in the compose file so remember the networking IP)
 OUTBOUND_ENDPOINT=http://dfspa-sdk-scheme-adapter:4001
-THIRDPARTY_OUTBOUND_ENDPOINT=http://dfspa-thirdparty-sdk-outbound:4006
 
 # The simulator can automatically add fees when generating quote responses. Use this
 # variable to control the fee amounts added. e.g. for a transfer of 100 USD a FEE_MULTIPLIER of 0.1

--- a/docker-local/dfsp_b/dfsp_b_backend.env
+++ b/docker-local/dfsp_b/dfsp_b_backend.env
@@ -30,7 +30,6 @@ MODEL_DATABASE=./model.sqlite
 
 # Outbound API endpoint (It might be a container in the compose file so remember the networking IP)
 OUTBOUND_ENDPOINT=http://dfspb-sdk-scheme-adapter:4001
-THIRDPARTY_OUTBOUND_ENDPOINT=http://dfspb-thirdparty-sdk-outbound:4006
 
 # The simulator can automatically add fees when generating quote responses. Use this
 # variable to control the fee amounts added. e.g. for a transfer of 100 USD a FEE_MULTIPLIER of 0.1

--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -422,35 +422,6 @@ services:
       start_period: 30s
       interval: 30s
 
-  dfspa-thirdparty-sdk-outbound:
-    image: "mojaloop/thirdparty-sdk:v13.0.0"
-    # build:
-    #  context: https://github.com/mojaloop/thirdparty-sdk.git#feat/deterministic-test-consentids
-    #  dockerfile: ./docker/Dockerfile
-    container_name: dfspa-thirdparty-sdk-outbound
-    environment:
-      - NODE_ENV=e2e
-    command: sh -c "/opt/thirdparty-sdk/wait4/wait4.js dfspa-thirdparty-sdk && npm run start:outbound"
-    volumes:
-      - "./dfsp_a/secrets:/opt/thirdparty-sdk/secrets"
-      - "./dfsp_a/dfsp_a_thirdparty_sdk.json:/opt/thirdparty-sdk/dist/config/e2e.json"
-      - "./docker/wait4:/opt/thirdparty-sdk/wait4"
-    ports:
-      - "5006:4006"
-    networks:
-      - mojaloop-net
-    depends_on:
-      - dfspa-redis
-      - dfspa-sdk-scheme-adapter
-      - thirdparty-api-svc
-    restart: always
-    healthcheck:
-      test: wget -q http://localhost:4006/health -O /dev/null || exit 1
-      timeout: 3s
-      retries: 10
-      start_period: 10s
-      interval: 30s
-
   dfspa-redis:
     container_name: dfspa-redis
     image: "redis:5.0.4-alpine"
@@ -521,36 +492,6 @@ services:
       retries: 10
       start_period: 10s
       interval: 30s
-
-  dfspb-thirdparty-sdk-outbound:
-    image: "mojaloop/thirdparty-sdk:v13.0.0"
-    #build:
-    #  context: https://github.com/username/thirdparty-sdk.git#feat/branch
-    #  dockerfile: ./docker/Dockerfile
-    container_name: dfspb-thirdparty-sdk-outbound
-    environment:
-      - NODE_ENV=e2e
-    command: sh -c "/opt/thirdparty-sdk/wait4/wait4.js dfspb-thirdparty-sdk && npm run start:outbound"
-    volumes:
-      - "./dfsp_b/secrets:/opt/thirdparty-sdk/secrets"
-      - "./dfsp_b/dfsp_b_thirdparty_sdk.json:/opt/thirdparty-sdk/dist/config/e2e.json"
-      - "./docker/wait4:/opt/thirdparty-sdk/wait4"
-    ports:
-      - "6006:4006"
-    networks:
-      - mojaloop-net
-    depends_on:
-      - dfspb-redis
-      - dfspb-sdk-scheme-adapter
-      - thirdparty-api-svc
-    restart: always
-    healthcheck:
-      test: wget -q http://localhost:4006/health -O /dev/null || exit 1
-      timeout: 3s
-      retries: 10
-      start_period: 10s
-      interval: 30s
-
   dfspb-redis:
     container_name: dfspb-redis
     image: "redis:5.0.4-alpine"

--- a/scripts/_setup_hosts_file.sh
+++ b/scripts/_setup_hosts_file.sh
@@ -19,7 +19,7 @@ echo "
 # to allow local access to mojaloop docker-compose environment
 127.0.0.1       central-ledger.local central-settlement.local ml-api-adapter.local account-lookup-service.local account-lookup-service-admin.local quoting-service.local moja-simulator.local central-ledger central-settlement ml-api-adapter account-lookup-service account-lookup-service-admin quoting-service simulator host.docker.internal
 127.0.0.1       dfspa-backend dfspb-backend pisp-backend dfspa-sdk-scheme-adapter dfspb-sdk-scheme-adapter pisp-sdk-scheme-adapter transaction-request-service
-127.0.0.1       pisp-thirdparty-sdk-inbound pisp-thirdparty-sdk-outbound dfspa-thirdparty-sdk-inbound dfspa-thirdparty-sdk-outbound dfspb-thirdparty-sdk-inbound dfspb-thirdparty-sdk-outbound
+127.0.0.1       pisp-thirdparty-sdk-inbound pisp-thirdparty-sdk-outbound dfspa-thirdparty-sdk-inbound dfspb-thirdparty-sdk-inbound
 # end of section
 " >> ${HOSTS_FILE}
 

--- a/scripts/_wait4_all.js
+++ b/scripts/_wait4_all.js
@@ -15,12 +15,10 @@ const expectedContainers = [
   // 'dfspa-backend', no health check
   // 'dfspa-sdk-scheme-adapter', no health check
   'dfspa-thirdparty-sdk-inbound',
-  'dfspa-thirdparty-sdk-outbound',
   // 'dfspa-redis', no health check
   // 'dfspb-backend', no health check
   // 'dfspb-sdk-scheme-adapter', no health check
   'dfspb-thirdparty-sdk-inbound',
-  'dfspb-thirdparty-sdk-outbound',
   // 'dfspb-redis', no health check
   // 'pisp-backend', no health check
   // 'pisp-sdk-scheme-adapter', no health check


### PR DESCRIPTION
DFSP's don't need an outbound server running since the outbound interface is solely for 3PPI's.

This is just my sanity check while I think about refactoring the `thirdparty-sdk` to seperate DFSP and 3PPI interfaces and logic from each other.